### PR TITLE
fix: terraform output after the resources are destroyed without any error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.43.0
+    rev: v1.44.0
     hooks:
       - id: terraform_fmt
+      - id: terraform_validate
       - id: terraform_docs
       - id: terraform_tflint
         args:
@@ -20,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-merge-conflict

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -173,3 +173,12 @@ resource "aws_cognito_user_pool" "this" {
 #    }
 #  ]
 #}
+
+###########
+# Disabled
+###########
+module "disabled" {
+  source = "../../"
+
+  create_graphql_api = false
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,5 +40,5 @@ output "this_appsync_resolver_arn" {
 # Extra
 output "this_appsync_graphql_api_fqdns" {
   description = "Map of FQDNs associated with the API (no protocol and path)"
-  value       =  length(aws_appsync_graphql_api.this) != 0 ? { for k, v in element(concat(aws_appsync_graphql_api.this.*.uris, [""]), 0) : k => regex("://([^/?#]*)?", v)[0] } : {}
+  value       = length(aws_appsync_graphql_api.this) != 0 ? { for k, v in element(concat(aws_appsync_graphql_api.this.*.uris, [""]), 0) : k => regex("://([^/?#]*)?", v)[0] } : {}
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,5 +40,5 @@ output "this_appsync_resolver_arn" {
 # Extra
 output "this_appsync_graphql_api_fqdns" {
   description = "Map of FQDNs associated with the API (no protocol and path)"
-  value       = { for k, v in element(concat(aws_appsync_graphql_api.this.*.uris, [""]), 0) : k => regex("://([^/?#]*)?", v)[0] }
+  value       =  length(aws_appsync_graphql_api.this) != 0 ? { for k, v in element(concat(aws_appsync_graphql_api.this.*.uris, [""]), 0) : k => regex("://([^/?#]*)?", v)[0] } : {}
 }


### PR DESCRIPTION
This is useful after a resource is destroyed and output variables are referred.
The other option could be checking the uri key name but when length is 1/0, the above statement also has a the same impact.

## Description
```aws_appsync_graphql_api.this.*.uris``` value should be checked before using. When the resource is destroyed , reference to uri key will give an issue .

## Motivation and Context
terraform destroy doesnt throw up any error

## Breaking Changes
None

## How Has This Been Tested?
No major changes, this checks if length of graphql api is o.
This has been tested in aws environment.