### PR TITLE
fix: dynamodb service role.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfstate
 *.tfstate*
 terraform.tfvars
+.terraform.lock.hcl

--- a/iam.tf
+++ b/iam.tf
@@ -19,7 +19,10 @@ locals {
         dynamodb = {
           effect    = "Allow"
           actions   = lookup(v, "policy_actions", null) == null ? var.dynamodb_allowed_actions : v.policy_actions
-          resources = [format("arn:aws:dynamodb:%v:%v:table/%v", v.region, lookup(v, "aws_account_id", data.aws_caller_identity.this.account_id), v.table_name)]
+          resources = [
+		format("arn:aws:dynamodb:%v:%v:table/%v", v.region, lookup(v, "aws_account_id", data.aws_caller_identity.this.account_id), v.table_name),
+		format("arn:aws:dynamodb:%v:%v:table/%v/*", v.region, lookup(v, "aws_account_id", data.aws_caller_identity.this.account_id), v.table_name)
+		]
         }
       }
     }

--- a/iam.tf
+++ b/iam.tf
@@ -19,10 +19,7 @@ locals {
         dynamodb = {
           effect    = "Allow"
           actions   = lookup(v, "policy_actions", null) == null ? var.dynamodb_allowed_actions : v.policy_actions
-          resources = [
-		format("arn:aws:dynamodb:%v:%v:table/%v", v.region, lookup(v, "aws_account_id", data.aws_caller_identity.this.account_id), v.table_name),
-		format("arn:aws:dynamodb:%v:%v:table/%v/*", v.region, lookup(v, "aws_account_id", data.aws_caller_identity.this.account_id), v.table_name)
-		]
+          resources = [for _, f in ["arn:aws:dynamodb:%v:%v:table/%v", "arn:aws:dynamodb:%v:%v:table/%v/*"] : format(f, v.region, lookup(v, "aws_account_id", data.aws_caller_identity.this.account_id), v.table_name)]
         }
       }
     }


### PR DESCRIPTION
This commit fixed dynamodb service role.
Otherwise APPSYNC_ASSUME_ROLE is not authorized to perform any action for AMAZON_DYNAMODB data source

This is the error that appears if you don't make this change.

` "message": "User: arn:aws:sts::XXXXXXXXXX:assumed-role/dynamodb-role/APPSYNC_ASSUME_ROLE is not authorized to perform: dynamodb:Query on resource: arn:aws:dynamodb:eu-central-1:XXXXXXXXXX:assumed:table/dynamodb-table/index/GS3 (Service: DynamoDb, Status Code: 400, Request ID: 2FK1667S31A74B546S0FJAOB6JVV4KQNSO5AEMVJF66Q9ASUAAJG, Extended Request ID: null)"`

## Description
DynamoDB policy needs to be defined also with table_name/*

```
Resource = "arn:aws:dynamodb:eu-central-1:886570723916:table/ns-development-tf-voiceland-dev" -> [
                          + "arn:aws:dynamodb:eu-central-1:886570723916:table/ns-development-tf-voiceland-dev/*",
                          + "arn:aws:dynamodb:eu-central-1:886570723916:table/ns-development-tf-voiceland-dev",
                        ]
```

## Motivation and Context
This fix is needed for DynamoDB Datasource to be able to work.

## Breaking Changes
This change only adds an extra resource definition on amazon dynamodb service policy so there is no braking changes.

## How Has This Been Tested?
I have created a dynamodb table and tried to fetch data from it using graphql api using this terraform module
