### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -126,77 +126,79 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 2.46 |
-| random | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.46 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_appsync_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_api_key) |
-| [aws_appsync_datasource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_datasource) |
-| [aws_appsync_graphql_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_graphql_api) |
-| [aws_appsync_resolver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_resolver) |
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| Name | Type |
+|------|------|
+| [aws_appsync_api_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_api_key) | resource |
+| [aws_appsync_datasource.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_datasource) | resource |
+| [aws_appsync_graphql_api.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_graphql_api) | resource |
+| [aws_appsync_resolver.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_resolver) | resource |
+| [aws_iam_role.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.service_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_authentication\_provider | One or more additional authentication providers for the GraphqlApi. | `any` | `{}` | no |
-| api\_keys | Map of API keys to create | `map(string)` | `{}` | no |
-| authentication\_type | The authentication type to use by GraphQL API | `string` | `"API_KEY"` | no |
-| create\_graphql\_api | Whether to create GraphQL API | `bool` | `true` | no |
-| create\_logs\_role | Whether to create service role for Cloudwatch logs | `bool` | `true` | no |
-| datasources | Map of datasources to create | `any` | `{}` | no |
-| direct\_lambda\_request\_template | VTL request template for the direct lambda integrations | `string` | `"{\n  \"version\" : \"2017-02-28\",\n  \"operation\": \"Invoke\",\n  \"payload\": {\n    \"arguments\": $util.toJson($ctx.arguments),\n    \"identity\": $util.toJson($ctx.identity),\n    \"source\": $util.toJson($ctx.source),\n    \"request\": $util.toJson($ctx.request),\n    \"prev\": $util.toJson($ctx.prev),\n    \"info\": {\n        \"selectionSetList\": $util.toJson($ctx.info.selectionSetList),\n        \"selectionSetGraphQL\": $util.toJson($ctx.info.selectionSetGraphQL),\n        \"parentTypeName\": $util.toJson($ctx.info.parentTypeName),\n        \"fieldName\": $util.toJson($ctx.info.fieldName),\n        \"variables\": $util.toJson($ctx.info.variables)\n    },\n    \"stash\": $util.toJson($ctx.stash)\n  }\n}\n"` | no |
-| direct\_lambda\_response\_template | VTL response template for the direct lambda integrations | `string` | `"$util.toJson($ctx.result)\n"` | no |
-| dynamodb\_allowed\_actions | List of allowed IAM actions for datasources type AMAZON\_DYNAMODB | `list(string)` | <pre>[<br>  "dynamodb:GetItem",<br>  "dynamodb:PutItem",<br>  "dynamodb:DeleteItem",<br>  "dynamodb:UpdateItem",<br>  "dynamodb:Query",<br>  "dynamodb:Scan",<br>  "dynamodb:BatchGetItem",<br>  "dynamodb:BatchWriteItem"<br>]</pre> | no |
-| elasticsearch\_allowed\_actions | List of allowed IAM actions for datasources type AMAZON\_ELASTICSEARCH | `list(string)` | <pre>[<br>  "es:ESHttpDelete",<br>  "es:ESHttpHead",<br>  "es:ESHttpGet",<br>  "es:ESHttpPost",<br>  "es:ESHttpPut"<br>]</pre> | no |
-| graphql\_api\_tags | Map of tags to add to GraphQL API | `map(string)` | `{}` | no |
-| lambda\_allowed\_actions | List of allowed IAM actions for datasources type AWS\_LAMBDA | `list(string)` | <pre>[<br>  "lambda:invokeFunction"<br>]</pre> | no |
-| log\_cloudwatch\_logs\_role\_arn | Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account. | `string` | `null` | no |
-| log\_exclude\_verbose\_content | Set to TRUE to exclude sections that contain information such as headers, context, and evaluated mapping templates, regardless of logging level. | `bool` | `false` | no |
-| log\_field\_log\_level | Field logging level. Valid values: ALL, ERROR, NONE. | `string` | `null` | no |
-| logging\_enabled | Whether to enable Cloudwatch logging on GraphQL API | `bool` | `false` | no |
-| logs\_role\_name | Name of IAM role to create for Cloudwatch logs | `string` | `null` | no |
-| logs\_role\_tags | Map of tags to add to Cloudwatch logs IAM role | `map(string)` | `{}` | no |
-| name | Name of GraphQL API | `string` | `""` | no |
-| openid\_connect\_config | Nested argument containing OpenID Connect configuration. | `map(string)` | `{}` | no |
-| resolver\_caching\_ttl | Default caching TTL for resolvers when caching is enabled | `number` | `60` | no |
-| resolvers | Map of resolvers to create | `any` | `{}` | no |
-| schema | The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration. | `string` | `""` | no |
-| tags | Map of tags to add to all GraphQL resources created by this module | `map(string)` | `{}` | no |
-| user\_pool\_config | The Amazon Cognito User Pool configuration. | `map(string)` | `{}` | no |
-| xray\_enabled | Whether tracing with X-ray is enabled. | `bool` | `false` | no |
+| <a name="input_additional_authentication_provider"></a> [additional\_authentication\_provider](#input\_additional\_authentication\_provider) | One or more additional authentication providers for the GraphqlApi. | `any` | `{}` | no |
+| <a name="input_api_keys"></a> [api\_keys](#input\_api\_keys) | Map of API keys to create | `map(string)` | `{}` | no |
+| <a name="input_authentication_type"></a> [authentication\_type](#input\_authentication\_type) | The authentication type to use by GraphQL API | `string` | `"API_KEY"` | no |
+| <a name="input_create_graphql_api"></a> [create\_graphql\_api](#input\_create\_graphql\_api) | Whether to create GraphQL API | `bool` | `true` | no |
+| <a name="input_create_logs_role"></a> [create\_logs\_role](#input\_create\_logs\_role) | Whether to create service role for Cloudwatch logs | `bool` | `true` | no |
+| <a name="input_datasources"></a> [datasources](#input\_datasources) | Map of datasources to create | `any` | `{}` | no |
+| <a name="input_direct_lambda_request_template"></a> [direct\_lambda\_request\_template](#input\_direct\_lambda\_request\_template) | VTL request template for the direct lambda integrations | `string` | `"{\n  \"version\" : \"2017-02-28\",\n  \"operation\": \"Invoke\",\n  \"payload\": {\n    \"arguments\": $util.toJson($ctx.arguments),\n    \"identity\": $util.toJson($ctx.identity),\n    \"source\": $util.toJson($ctx.source),\n    \"request\": $util.toJson($ctx.request),\n    \"prev\": $util.toJson($ctx.prev),\n    \"info\": {\n        \"selectionSetList\": $util.toJson($ctx.info.selectionSetList),\n        \"selectionSetGraphQL\": $util.toJson($ctx.info.selectionSetGraphQL),\n        \"parentTypeName\": $util.toJson($ctx.info.parentTypeName),\n        \"fieldName\": $util.toJson($ctx.info.fieldName),\n        \"variables\": $util.toJson($ctx.info.variables)\n    },\n    \"stash\": $util.toJson($ctx.stash)\n  }\n}\n"` | no |
+| <a name="input_direct_lambda_response_template"></a> [direct\_lambda\_response\_template](#input\_direct\_lambda\_response\_template) | VTL response template for the direct lambda integrations | `string` | `"$util.toJson($ctx.result)\n"` | no |
+| <a name="input_dynamodb_allowed_actions"></a> [dynamodb\_allowed\_actions](#input\_dynamodb\_allowed\_actions) | List of allowed IAM actions for datasources type AMAZON\_DYNAMODB | `list(string)` | <pre>[<br>  "dynamodb:GetItem",<br>  "dynamodb:PutItem",<br>  "dynamodb:DeleteItem",<br>  "dynamodb:UpdateItem",<br>  "dynamodb:Query",<br>  "dynamodb:Scan",<br>  "dynamodb:BatchGetItem",<br>  "dynamodb:BatchWriteItem"<br>]</pre> | no |
+| <a name="input_elasticsearch_allowed_actions"></a> [elasticsearch\_allowed\_actions](#input\_elasticsearch\_allowed\_actions) | List of allowed IAM actions for datasources type AMAZON\_ELASTICSEARCH | `list(string)` | <pre>[<br>  "es:ESHttpDelete",<br>  "es:ESHttpHead",<br>  "es:ESHttpGet",<br>  "es:ESHttpPost",<br>  "es:ESHttpPut"<br>]</pre> | no |
+| <a name="input_graphql_api_tags"></a> [graphql\_api\_tags](#input\_graphql\_api\_tags) | Map of tags to add to GraphQL API | `map(string)` | `{}` | no |
+| <a name="input_lambda_allowed_actions"></a> [lambda\_allowed\_actions](#input\_lambda\_allowed\_actions) | List of allowed IAM actions for datasources type AWS\_LAMBDA | `list(string)` | <pre>[<br>  "lambda:invokeFunction"<br>]</pre> | no |
+| <a name="input_log_cloudwatch_logs_role_arn"></a> [log\_cloudwatch\_logs\_role\_arn](#input\_log\_cloudwatch\_logs\_role\_arn) | Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account. | `string` | `null` | no |
+| <a name="input_log_exclude_verbose_content"></a> [log\_exclude\_verbose\_content](#input\_log\_exclude\_verbose\_content) | Set to TRUE to exclude sections that contain information such as headers, context, and evaluated mapping templates, regardless of logging level. | `bool` | `false` | no |
+| <a name="input_log_field_log_level"></a> [log\_field\_log\_level](#input\_log\_field\_log\_level) | Field logging level. Valid values: ALL, ERROR, NONE. | `string` | `null` | no |
+| <a name="input_logging_enabled"></a> [logging\_enabled](#input\_logging\_enabled) | Whether to enable Cloudwatch logging on GraphQL API | `bool` | `false` | no |
+| <a name="input_logs_role_name"></a> [logs\_role\_name](#input\_logs\_role\_name) | Name of IAM role to create for Cloudwatch logs | `string` | `null` | no |
+| <a name="input_logs_role_tags"></a> [logs\_role\_tags](#input\_logs\_role\_tags) | Map of tags to add to Cloudwatch logs IAM role | `map(string)` | `{}` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of GraphQL API | `string` | `""` | no |
+| <a name="input_openid_connect_config"></a> [openid\_connect\_config](#input\_openid\_connect\_config) | Nested argument containing OpenID Connect configuration. | `map(string)` | `{}` | no |
+| <a name="input_resolver_caching_ttl"></a> [resolver\_caching\_ttl](#input\_resolver\_caching\_ttl) | Default caching TTL for resolvers when caching is enabled | `number` | `60` | no |
+| <a name="input_resolvers"></a> [resolvers](#input\_resolvers) | Map of resolvers to create | `any` | `{}` | no |
+| <a name="input_schema"></a> [schema](#input\_schema) | The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration. | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to add to all GraphQL resources created by this module | `map(string)` | `{}` | no |
+| <a name="input_user_pool_config"></a> [user\_pool\_config](#input\_user\_pool\_config) | The Amazon Cognito User Pool configuration. | `map(string)` | `{}` | no |
+| <a name="input_xray_enabled"></a> [xray\_enabled](#input\_xray\_enabled) | Whether tracing with X-ray is enabled. | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_appsync\_api\_key\_id | Map of API Key ID (Formatted as ApiId:Key) |
-| this\_appsync\_api\_key\_key | Map of API Keys |
-| this\_appsync\_datasource\_arn | Map of ARNs of datasources |
-| this\_appsync\_graphql\_api\_arn | ARN of GraphQL API |
-| this\_appsync\_graphql\_api\_fqdns | Map of FQDNs associated with the API (no protocol and path) |
-| this\_appsync\_graphql\_api\_id | ID of GraphQL API |
-| this\_appsync\_graphql\_api\_uris | Map of URIs associated with the API |
-| this\_appsync\_resolver\_arn | Map of ARNs of resolvers |
+| <a name="output_this_appsync_api_key_id"></a> [this\_appsync\_api\_key\_id](#output\_this\_appsync\_api\_key\_id) | Map of API Key ID (Formatted as ApiId:Key) |
+| <a name="output_this_appsync_api_key_key"></a> [this\_appsync\_api\_key\_key](#output\_this\_appsync\_api\_key\_key) | Map of API Keys |
+| <a name="output_this_appsync_datasource_arn"></a> [this\_appsync\_datasource\_arn](#output\_this\_appsync\_datasource\_arn) | Map of ARNs of datasources |
+| <a name="output_this_appsync_graphql_api_arn"></a> [this\_appsync\_graphql\_api\_arn](#output\_this\_appsync\_graphql\_api\_arn) | ARN of GraphQL API |
+| <a name="output_this_appsync_graphql_api_fqdns"></a> [this\_appsync\_graphql\_api\_fqdns](#output\_this\_appsync\_graphql\_api\_fqdns) | Map of FQDNs associated with the API (no protocol and path) |
+| <a name="output_this_appsync_graphql_api_id"></a> [this\_appsync\_graphql\_api\_id](#output\_this\_appsync\_graphql\_api\_id) | ID of GraphQL API |
+| <a name="output_this_appsync_graphql_api_uris"></a> [this\_appsync\_graphql\_api\_uris](#output\_this\_appsync\_graphql\_api\_uris) | Map of URIs associated with the API |
+| <a name="output_this_appsync_resolver_arn"></a> [this\_appsync\_resolver\_arn](#output\_this\_appsync\_resolver\_arn) | Map of ARNs of resolvers |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,45 +20,45 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 2.46 |
-| random | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.46 |
-| random | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.46 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| appsync | ../../ |  |
-| disabled | ../../ |  |
+| <a name="module_appsync"></a> [appsync](#module\_appsync) | ../../ |  |
+| <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ |  |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_cognito_user_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_cognito_user_pool.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_appsync\_api\_key\_id | Map of API Key ID (Formatted as ApiId:Key) |
-| this\_appsync\_api\_key\_key | Map of API Keys |
-| this\_appsync\_datasource\_arn | Map of ARNs of datasources |
-| this\_appsync\_graphql\_api\_arn | ARN of GraphQL API |
-| this\_appsync\_graphql\_api\_fqdns | Map of FQDNs associated with the API (no protocol and path) |
-| this\_appsync\_graphql\_api\_id | ID of GraphQL API |
-| this\_appsync\_graphql\_api\_uris | Map of URIs associated with the API |
-| this\_appsync\_resolver\_arn | Map of ARNs of resolvers |
+| <a name="output_this_appsync_api_key_id"></a> [this\_appsync\_api\_key\_id](#output\_this\_appsync\_api\_key\_id) | Map of API Key ID (Formatted as ApiId:Key) |
+| <a name="output_this_appsync_api_key_key"></a> [this\_appsync\_api\_key\_key](#output\_this\_appsync\_api\_key\_key) | Map of API Keys |
+| <a name="output_this_appsync_datasource_arn"></a> [this\_appsync\_datasource\_arn](#output\_this\_appsync\_datasource\_arn) | Map of ARNs of datasources |
+| <a name="output_this_appsync_graphql_api_arn"></a> [this\_appsync\_graphql\_api\_arn](#output\_this\_appsync\_graphql\_api\_arn) | ARN of GraphQL API |
+| <a name="output_this_appsync_graphql_api_fqdns"></a> [this\_appsync\_graphql\_api\_fqdns](#output\_this\_appsync\_graphql\_api\_fqdns) | Map of FQDNs associated with the API (no protocol and path) |
+| <a name="output_this_appsync_graphql_api_id"></a> [this\_appsync\_graphql\_api\_id](#output\_this\_appsync\_graphql\_api\_id) | ID of GraphQL API |
+| <a name="output_this_appsync_graphql_api_uris"></a> [this\_appsync\_graphql\_api\_uris](#output\_this\_appsync\_graphql\_api\_uris) | Map of URIs associated with the API |
+| <a name="output_this_appsync_resolver_arn"></a> [this\_appsync\_resolver\_arn](#output\_this\_appsync\_resolver\_arn) | Map of ARNs of resolvers |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
