### PR TITLE
set api_key_key output to be sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,7 @@ output "appsync_api_key_id" {
 output "appsync_api_key_key" {
   description = "Map of API Keys"
   value       = { for k, v in aws_appsync_api_key.this : k => v.key }
+  sensitive   = true
 }
 
 # Datasources


### PR DESCRIPTION
The output of the variable appsync_api_key_key is set to be sensitive since it contains sensitive information.
