### PR TITLE
feat: adding iam_permission_boundary to role creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,4 @@ All notable changes to this project will be documented in this file.
 [v0.4.0]: https://github.com/terraform-aws-modules/terraform-aws-appsync/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/terraform-aws-modules/terraform-aws-appsync/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/terraform-aws-modules/terraform-aws-appsync/compare/v0.1.0...v0.2.0
+

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
@@ -158,6 +158,7 @@ No modules.
 | <a name="input_elasticsearch_allowed_actions"></a> [elasticsearch\_allowed\_actions](#input\_elasticsearch\_allowed\_actions) | List of allowed IAM actions for datasources type AMAZON\_ELASTICSEARCH | `list(string)` | <pre>[<br>  "es:ESHttpDelete",<br>  "es:ESHttpHead",<br>  "es:ESHttpGet",<br>  "es:ESHttpPost",<br>  "es:ESHttpPut"<br>]</pre> | no |
 | <a name="input_functions"></a> [functions](#input\_functions) | Map of functions to create | `any` | `{}` | no |
 | <a name="input_graphql_api_tags"></a> [graphql\_api\_tags](#input\_graphql\_api\_tags) | Map of tags to add to GraphQL API | `map(string)` | `{}` | no |
+| <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | ARN for iam permissions boundary | `string` | `null` | no |
 | <a name="input_lambda_allowed_actions"></a> [lambda\_allowed\_actions](#input\_lambda\_allowed\_actions) | List of allowed IAM actions for datasources type AWS\_LAMBDA | `list(string)` | <pre>[<br>  "lambda:invokeFunction"<br>]</pre> | no |
 | <a name="input_log_cloudwatch_logs_role_arn"></a> [log\_cloudwatch\_logs\_role\_arn](#input\_log\_cloudwatch\_logs\_role\_arn) | Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account. | `string` | `null` | no |
 | <a name="input_log_exclude_verbose_content"></a> [log\_exclude\_verbose\_content](#input\_log\_exclude\_verbose\_content) | Set to TRUE to exclude sections that contain information such as headers, context, and evaluated mapping templates, regardless of logging level. | `bool` | `false` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 2.46"

--- a/iam.tf
+++ b/iam.tf
@@ -62,12 +62,11 @@ data "aws_iam_policy_document" "assume_role" {
 resource "aws_iam_role" "logs" {
   count = var.logging_enabled && var.create_logs_role ? 1 : 0
 
-  name               = coalesce(var.logs_role_name, "${var.name}-logs")
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-
+  name                 = coalesce(var.logs_role_name, "${var.name}-logs")
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
   permissions_boundary = var.iam_permissions_boundary
 
-  tags               = merge(var.tags, var.logs_role_tags)
+  tags = merge(var.tags, var.logs_role_tags)
 }
 
 resource "aws_iam_role_policy_attachment" "logs" {
@@ -81,11 +80,9 @@ resource "aws_iam_role_policy_attachment" "logs" {
 resource "aws_iam_role" "service_role" {
   for_each = local.service_roles_with_specific_policies
 
-  name = lookup(each.value, "service_role_name", "${each.key}-role")
-
+  name                 = lookup(each.value, "service_role_name", "${each.key}-role")
   permissions_boundary = var.iam_permissions_boundary
-
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "this" {

--- a/iam.tf
+++ b/iam.tf
@@ -64,6 +64,9 @@ resource "aws_iam_role" "logs" {
 
   name               = coalesce(var.logs_role_name, "${var.name}-logs")
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
+
+  permissions_boundary = var.iam_permissions_boundary
+
   tags               = merge(var.tags, var.logs_role_tags)
 }
 
@@ -79,6 +82,8 @@ resource "aws_iam_role" "service_role" {
   for_each = local.service_roles_with_specific_policies
 
   name = lookup(each.value, "service_role_name", "${each.key}-role")
+
+  permissions_boundary = var.iam_permissions_boundary
 
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,12 @@ variable "elasticsearch_allowed_actions" {
   default     = ["es:ESHttpDelete", "es:ESHttpHead", "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut"]
 }
 
+variable "iam_permissions_boundary" {
+  description = "ARN for iam permissions boundary"
+  type        = string
+  default     = null
+}
+
 # VTL request/response templates
 variable "direct_lambda_request_template" {
   description = "VTL request template for the direct lambda integrations"
@@ -187,11 +193,3 @@ variable "functions" {
   type        = any
   default     = {}
 }
-
-variable "iam_permissions_boundary" {
-  type = string
-  description = "ARN for iam permissions boundary"
-  default = null
-
-}
-

--- a/variables.tf
+++ b/variables.tf
@@ -187,3 +187,11 @@ variable "functions" {
   type        = any
   default     = {}
 }
+
+variable "iam_permissions_boundary" {
+  type = string
+  description = "ARN for iam permissions boundary"
+  default = null
+
+}
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 2.46"


### PR DESCRIPTION
## Description
For most of our setup we need the permission_boundary set to be able to create iam_roles 
This change will add the permission boundary to the roles create with the modle 

## Motivation and Context
For our setup the iam roles cannot be created without an permission_boundary 

## Breaking Changes
I guess no breaking change since it is not a required variable

## How Has This Been Tested?
 The change was tested by using as a module as following 
```terraform
module "appsync" {
  // for now my github branch till pullrequest is accepted
  source = "github.com/jakubikan/terraform-aws-appsync"

  name  = "api-app-${var.environment}"

  schema = file("${path.module}/main.graphqls")

  iam_permissions_boundary = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/boundary"

  api_keys = {
    default = null # such key will expire in 7 days
  }

  datasources = {
   lambda = {
      type         = "AWS_LAMBDA"
      function_arn = module.lambda.arn
    }
  }

  resolvers = {
    "Query.someQuery" = {
      data_source   = "lambda"
      direct_lambda = true
    }
  }

```
