### PR TITLE
feat: Added support for lambda_authorization_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.70 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.70 |
 
 ## Modules
 
@@ -160,6 +160,7 @@ No modules.
 | <a name="input_graphql_api_tags"></a> [graphql\_api\_tags](#input\_graphql\_api\_tags) | Map of tags to add to GraphQL API | `map(string)` | `{}` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | ARN for iam permissions boundary | `string` | `null` | no |
 | <a name="input_lambda_allowed_actions"></a> [lambda\_allowed\_actions](#input\_lambda\_allowed\_actions) | List of allowed IAM actions for datasources type AWS\_LAMBDA | `list(string)` | <pre>[<br>  "lambda:invokeFunction"<br>]</pre> | no |
+| <a name="input_lambda_authorizer_config"></a> [lambda\_authorizer\_config](#input\_lambda\_authorizer\_config) | Nested argument containing Lambda authorizer configuration. | `map(string)` | `{}` | no |
 | <a name="input_log_cloudwatch_logs_role_arn"></a> [log\_cloudwatch\_logs\_role\_arn](#input\_log\_cloudwatch\_logs\_role\_arn) | Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account. | `string` | `null` | no |
 | <a name="input_log_exclude_verbose_content"></a> [log\_exclude\_verbose\_content](#input\_log\_exclude\_verbose\_content) | Set to TRUE to exclude sections that contain information such as headers, context, and evaluated mapping templates, regardless of logging level. | `bool` | `false` | no |
 | <a name="input_log_field_log_level"></a> [log\_field\_log\_level](#input\_log\_field\_log\_level) | Field logging level. Valid values: ALL, ERROR, NONE. | `string` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -25,6 +25,10 @@ module "appsync" {
 
   authentication_type = "OPENID_CONNECT"
 
+  lambda_authorizer_config = {
+    authorizer_uri = "arn:aws:lambda:eu-west-1:835367859851:function:appsync_auth_1"
+  }
+
   openid_connect_config = {
     issuer    = "https://www.issuer1.com/"
     client_id = "client_id1"

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,16 @@ resource "aws_appsync_graphql_api" "this" {
     }
   }
 
+  dynamic "lambda_authorizer_config" {
+    for_each = length(keys(var.lambda_authorizer_config)) == 0 ? [] : [true]
+
+    content {
+      authorizer_uri                   = var.lambda_authorizer_config["authorizer_uri"]
+      authorizer_result_ttl_in_seconds = lookup(var.lambda_authorizer_config, "authorizer_result_ttl_in_seconds", null)
+      identity_validation_expression   = lookup(var.lambda_authorizer_config, "identity_validation_expression", null)
+    }
+  }
+
   dynamic "openid_connect_config" {
     for_each = length(keys(var.openid_connect_config)) == 0 ? [] : [true]
 

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,12 @@ variable "log_exclude_verbose_content" {
   default     = false
 }
 
+variable "lambda_authorizer_config" {
+  description = "Nested argument containing Lambda authorizer configuration."
+  type        = map(string)
+  default     = {}
+}
+
 variable "openid_connect_config" {
   description = "Nested argument containing OpenID Connect configuration."
   type        = map(string)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.46"
+      version = ">= 3.70"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Description
Add `lambda_authorization_config` variable and dynamic argument to module.

## Motivation and Context
AWS Lambda authorization was added in 3.70.0 https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_graphql_api#aws-lambda-authorizer-authentication

Fixes https://github.com/terraform-aws-modules/terraform-aws-appsync/issues/19

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
~~I haven't had a chance to test these, personally. If I get the chance before somebody else does, I will update this section.~~

Was able to confirm this working with a test environment:

```hcl
...

module "appsync_test" {
  source = "git::https://github.com/michaelhelmick/terraform-aws-appsync.git?ref=fc3f1c257b588ff457aaa3b5a716010010ac2d06"
  schema                     = data.template_file.schema.rendered
  name                         = "appsync-test"
  authentication_type = "AWS_LAMBDA"
  lambda_authorizer_config = {
    authorizer_uri = module.authorization_lambda.arn
  }
  ...
}
```

<img width="429" alt="Screen Shot 2021-12-20 at 12 02 12 PM" src="https://user-images.githubusercontent.com/352270/146804618-5cb0675c-2b32-408c-991b-0f8b1b16ac53.png">

Authorized and got a successful response.

