### PR TITLE
set api_key_key output to be sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,7 @@ output "appsync_api_key_id" {
 output "appsync_api_key_key" {
   description = "Map of API Keys"
   value       = { for k, v in aws_appsync_api_key.this : k => v.key }
+  sensitive   = true
 }
 
 # Datasources


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
api keys are sensitve information and should be secured. TF offers this in form of masking values as sensitive.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Increase security for api keys.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
modules referencing this module outputs need to mark their outputs also as sensitive.
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
