### PR TITLE
feat: Set api_key_key output to be sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,7 @@ output "appsync_api_key_id" {
 output "appsync_api_key_key" {
   description = "Map of API Keys"
   value       = { for k, v in aws_appsync_api_key.this : k => v.key }
+  sensitive   = true
 }
 
 # Datasources


### PR DESCRIPTION
Secure output of sensitive api key

fix(precommit): update config and docs

Signed-off-by: Steffen Tautenhahn <stevie-@users.noreply.github.com>

## Description
<!--- Describe your changes in detail -->
Secure sensitive api keys to increase security.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
API keys are sensible by nature and should be protected.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Output references from this module need to set sensitive as well.
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
