### PR TITLE
fix: Take app_id_client_regex from user_pool_config (#35)

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -44,6 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Type |
 |------|------|
 | [aws_cognito_user_pool.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
+| [aws_cognito_user_pool_client.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client) | resource |
 | [aws_route53_record.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -135,7 +135,8 @@ module "appsync" {
       authentication_type = "AMAZON_COGNITO_USER_POOLS"
 
       user_pool_config = {
-        user_pool_id = aws_cognito_user_pool.this.id
+        user_pool_id        = aws_cognito_user_pool.this.id
+        app_id_client_regex = aws_cognito_user_pool_client.this.id
       }
     }
   }
@@ -262,6 +263,11 @@ resource "random_pet" "this" {
 
 resource "aws_cognito_user_pool" "this" {
   name = "user-pool-${random_pet.this.id}"
+}
+
+resource "aws_cognito_user_pool_client" "this" {
+  name         = "user-pool-client-${random_pet.this.id}"
+  user_pool_id = aws_cognito_user_pool.this.id
 }
 
 #module "aws_lambda_function1" {

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -39,6 +39,7 @@ output "appsync_api_key_id" {
 output "appsync_api_key_key" {
   description = "Map of API Keys"
   value       = module.appsync.appsync_api_key_key
+  sensitive   = true
 }
 
 # Datasources

--- a/main.tf
+++ b/main.tf
@@ -51,8 +51,8 @@ resource "aws_appsync_graphql_api" "this" {
     content {
       default_action      = var.user_pool_config["default_action"]
       user_pool_id        = var.user_pool_config["user_pool_id"]
-      app_id_client_regex = lookup(var.openid_connect_config, "app_id_client_regex", null)
-      aws_region          = lookup(var.openid_connect_config, "aws_region", null)
+      app_id_client_regex = lookup(var.user_pool_config, "app_id_client_regex", null)
+      aws_region          = lookup(var.user_pool_config, "aws_region", null)
     }
   }
 


### PR DESCRIPTION
## Description
Fixes the configuration of aws_region and app_id_client_regex for cognito user pool auth.

## Motivation and Context
Fixes #35 

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
