### PR TITLE
feat: Add support to configure batch resolvers

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -205,8 +205,9 @@ EOF
     }
 
     "Post.id" = {
-      data_source   = "lambda2"
-      direct_lambda = true
+      data_source    = "lambda2"
+      direct_lambda  = true
+      max_batch_size = 10
     }
 
     "Post.title" = {

--- a/main.tf
+++ b/main.tf
@@ -204,7 +204,7 @@ resource "aws_appsync_resolver" "this" {
     }
   }
 
-  max_batch_size = lookup(each.value, "max_batch_size", 0)
+  max_batch_size = lookup(each.value, "max_batch_size", null)
 }
 
 # Functions

--- a/main.tf
+++ b/main.tf
@@ -203,6 +203,8 @@ resource "aws_appsync_resolver" "this" {
       ttl          = lookup(each.value, "caching_ttl", var.resolver_caching_ttl)
     }
   }
+
+  max_batch_size = lookup(each.value, "max_batch_size", 0)
 }
 
 # Functions


### PR DESCRIPTION
## Description
- Added support for `max_batch_size` in resource `aws_appsync_resolver`

## Motivation and Context
- Supports adding batching size for Lambda resolver. Check this [AWS blog post](https://aws.amazon.com/blogs/mobile/introducing-configurable-batching-size-for-aws-appsync-lambda-resolvers/)
- Related issue: https://github.com/terraform-aws-modules/terraform-aws-appsync/issues/37

## Breaking Changes
- No breaking change in this PR

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<img width="681" alt="main_tf_—_terraform-aws-appsync" src="https://user-images.githubusercontent.com/20262596/200985541-38dfaf78-58ca-4a67-90e9-5023ec1dcab1.png">
