### PR TITLE
fix: Replace hardcoded "aws" parition with data lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ No modules.
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.service_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 


### PR DESCRIPTION
## Description
Replaced hardcoded "aws" partition references in iam ARNs with the current partition (aws-cn, etc)

## Motivation and Context
These changes are needed so the terraform apply will work in China.  The current code results in `Error: putting IAM role policy service-policy: MalformedPolicyDocument: Partition "aws" is not valid for resource "arn:aws:dynamodb:cn-northwest-1...`

## Breaking Changes
None

## How Has This Been Tested?
I tested this by re-running my project that uses this module against China and it succeeded.  I also re-ran it against a US based region/partition and verified it shows no changes to what we already deployed.  I didn't update any of the examples since this is all behind-the-scenes and there's no effect to the user (other than it should now work in China).

