### PR TITLE
feat: Adds support for JavaScript AppSync Functions

### DIFF
--- a/examples/complete/src/function.js
+++ b/examples/complete/src/function.js
@@ -1,0 +1,27 @@
+/**
+ * These are available AWS AppSync utilities that you can use in your request and response handler.
+ * For more information about the utilities that are currently implemented, see
+ * https://docs.aws.amazon.com/en_us/appsync/latest/devguide/resolver-reference-overview-js.html#utility-resolvers.
+ */
+import { util } from '@aws-appsync/utils';
+
+/**
+ * This function handles an incoming request, then converts it into a request
+ * object for the selected data source operation.
+ * You can find more code samples here: https://github.com/aws-samples/aws-appsync-resolver-samples.
+ * @param ctx - Contextual information for your resolver invocation.
+ * @returns - A data source request object.
+ */
+export function request(ctx) {
+    return {};
+}
+
+/**
+ * This function handles the response from the data source.
+ * You can find more code samples here: https://github.com/aws-samples/aws-appsync-resolver-samples.
+ * @param ctx - Contextual information for your resolver invocation.
+ * @returns - A result that is passed to the next function, or the response handler of the pipeline resolver.
+ */
+export function response(ctx) {
+    return {};
+}


### PR DESCRIPTION
## Description
Currently the module does not support the newly released JavaScript runtime for AppSync Functions. Recently, the JS runtime was introduced (in this module) for resolvers, but not for functions.

Furthermore, I've added support for `sync_config` configuration.

## Motivation and Context
Resolves [Enable JS functions](#48)

## Breaking Changes
None.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
