### PR TITLE
feat!: Added appsync visibility option, bump AWS provider version to 5.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.80.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.1 |
 
 ## Modules
 
@@ -190,7 +190,7 @@ No modules.
 | <a name="input_schema"></a> [schema](#input\_schema) | The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to add to all GraphQL resources created by this module | `map(string)` | `{}` | no |
 | <a name="input_user_pool_config"></a> [user\_pool\_config](#input\_user\_pool\_config) | The Amazon Cognito User Pool configuration. | `map(string)` | `{}` | no |
-| <a name="input_visibility"></a> [visibility](#input\_visibility) | The API visibility. Valid values: GLOBAL, PRIVATE. | `string` | `"GLOBAL"` | no |
+| <a name="input_visibility"></a> [visibility](#input\_visibility) | The API visibility. Valid values: GLOBAL, PRIVATE. | `string` | `null` | no |
 | <a name="input_xray_enabled"></a> [xray\_enabled](#input\_xray\_enabled) | Whether tracing with X-ray is enabled. | `bool` | `false` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ module "appsync" {
 
   schema = file("schema.graphql")
 
+  visibility = "GLOBAL"
+
   api_keys = {
     default = null # such key will expire in 7 days
   }
@@ -112,14 +114,14 @@ $ terraform apply
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.49 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.1.0 |
 
 ## Modules
 
@@ -188,6 +190,7 @@ No modules.
 | <a name="input_schema"></a> [schema](#input\_schema) | The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to add to all GraphQL resources created by this module | `map(string)` | `{}` | no |
 | <a name="input_user_pool_config"></a> [user\_pool\_config](#input\_user\_pool\_config) | The Amazon Cognito User Pool configuration. | `map(string)` | `{}` | no |
+| <a name="input_visibility"></a> [visibility](#input\_visibility) | The API visibility. Valid values: GLOBAL, PRIVATE. | `string` | `"GLOBAL"` | no |
 | <a name="input_xray_enabled"></a> [xray\_enabled](#input\_xray\_enabled) | Whether tracing with X-ray is enabled. | `bool` | `false` | no |
 
 ## Outputs

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -21,14 +21,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.49 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.49 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -85,6 +85,8 @@ module "appsync" {
 
   schema = file("schema.graphql")
 
+  visibility = "GLOBAL"
+
   domain_name_association_enabled = true
   caching_enabled                 = true
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.49"
+      version = ">= 5.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ resource "aws_appsync_graphql_api" "this" {
   authentication_type = var.authentication_type
   schema              = var.schema
   xray_enabled        = var.xray_enabled
+  visibility          = var.visibility
 
   dynamic "log_config" {
     for_each = var.logging_enabled ? [true] : []

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,7 @@ variable "domain_name_association_enabled" {
   type        = bool
   default     = false
 }
+
 variable "caching_enabled" {
   description = "Whether caching with Elasticache is enabled."
   type        = bool
@@ -42,15 +43,7 @@ variable "schema" {
 variable "visibility" {
   description = "The API visibility. Valid values: GLOBAL, PRIVATE."
   type        = string
-  default     = "GLOBAL"
-
-  validation {
-    condition = contains([
-      "GLOBAL",
-      "PRIVATE"
-    ], var.visibility)
-    error_message = "Allowed values for input_parameter are \"GLOBAL\", or \"PRIVATE\"."
-  }
+  default     = null
 }
 
 variable "authentication_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,20 @@ variable "schema" {
   default     = ""
 }
 
+variable "visibility" {
+  description = "The API visibility. Valid values: GLOBAL, PRIVATE."
+  type        = string
+  default     = "GLOBAL"
+
+  validation {
+    condition = contains([
+      "GLOBAL",
+      "PRIVATE"
+    ], var.visibility)
+    error_message = "Allowed values for input_parameter are \"GLOBAL\", or \"PRIVATE\"."
+  }
+}
+
 variable "authentication_type" {
   description = "The authentication type to use by GraphQL API"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.1.0"
+      version = ">= 5.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.49"
+      version = ">= 5.1.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
AWS added a feature to AppSync to allow creating private APIs ([link to the article](https://docs.aws.amazon.com/appsync/latest/devguide/using-private-apis.html)).
Corresponding to that a [PR](https://github.com/hashicorp/terraform-provider-aws/pull/31369) hashicorp merged into release [5.1.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.1.0) of terraform-provider-aws.

In my PR i have added the visibility option to the appsync module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It adds a missing feature.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
