### PR TITLE
feat: Add lambda as additional auth provider

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -139,6 +139,13 @@ module "appsync" {
         app_id_client_regex = aws_cognito_user_pool_client.this.id
       }
     }
+
+    lambda = {
+      authentication_type = "AWS_LAMBDA"
+      lambda_authorizer_config = {
+        authorizer_uri = "arn:aws:lambda:eu-west-1:835367859851:function:appsync_auth_2"
+      }
+    }
   }
 
   functions = {

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,15 @@ resource "aws_appsync_graphql_api" "this" {
           aws_region          = lookup(user_pool_config.value, "aws_region", null)
         }
       }
+      dynamic "lambda_authorizer_config" {
+        for_each = length(keys(lookup(additional_authentication_provider.value, "lambda_authorizer_config", {}))) == 0 ? [] : [additional_authentication_provider.value.lambda_authorizer_config]
+
+        content {
+          authorizer_uri                   = lambda_authorizer_config.value.authorizer_uri
+          authorizer_result_ttl_in_seconds = lookup(lambda_authorizer_config.value, "authorizer_result_ttl_in_seconds", null)
+          identity_validation_expression   = lookup(lambda_authorizer_config.value, "identity_validation_expression", null)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Description

The change allows to use `AWS_LAMBDA` as additional auth provider. This block is missing in official AWS provider documentation [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appsync_graphql_api.html#additional_authentication_provider) but the block is supported.

## Motivation and Context

We use APIKEY as primary auth method and AWS_LAMBDA as additional.

## Breaking Changes

No breaking changes.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested on my production terraform code to validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
