### PR TITLE
fix: Fixed APPSYNC_JS resolvers for both kinds (UNIT and PIPELINE)

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -269,6 +269,18 @@ EOF
       ]
     }
 
+    "Query.singleComment" = {
+      kind  = "UNIT"
+      type  = "Query"
+      field = "singleComment"
+      code  = file("src/function.js")
+      runtime = {
+        name            = "APPSYNC_JS"
+        runtime_version = "1.0.0"
+      }
+      data_source = "dynamodb1"
+    }
+
     "Query.user" = {
       kind  = "PIPELINE"
       type  = "Query"

--- a/examples/complete/schema.graphql
+++ b/examples/complete/schema.graphql
@@ -12,10 +12,16 @@ type User {
   name: String
 }
 
+type Comment {
+  id: ID !
+  comment: String!
+}
+
 type Query {
   singlePost(id: ID!): Post
   none(dummyString: String!): String!
   user(id: ID!): User
+  singleComment(id: ID!): Comment
 }
 
 schema {

--- a/main.tf
+++ b/main.tf
@@ -201,7 +201,7 @@ resource "aws_appsync_resolver" "this" {
   }
 
   # code is required when runtime is APPSYNC_JS
-  code = try(each.value.kind == "PIPELINE" && each.value.runtime.name == "APPSYNC_JS", false) ? each.value.code : null
+  code = try(each.value.runtime.name == "APPSYNC_JS", false) ? each.value.code : null
 
   request_template  = lookup(each.value, "request_template", tobool(lookup(each.value, "direct_lambda", false)) ? var.direct_lambda_request_template : try(each.value.kind == "PIPELINE" && each.value.runtime.name == "APPSYNC_JS", false) ? null : "{}")
   response_template = lookup(each.value, "response_template", tobool(lookup(each.value, "direct_lambda", false)) ? var.direct_lambda_response_template : try(each.value.kind == "PIPELINE" && each.value.runtime.name == "APPSYNC_JS", false) ? null : "{}")

--- a/main.tf
+++ b/main.tf
@@ -203,8 +203,8 @@ resource "aws_appsync_resolver" "this" {
   # code is required when runtime is APPSYNC_JS
   code = try(each.value.runtime.name == "APPSYNC_JS", false) ? each.value.code : null
 
-  request_template  = lookup(each.value, "request_template", tobool(lookup(each.value, "direct_lambda", false)) ? var.direct_lambda_request_template : try(each.value.kind == "PIPELINE" && each.value.runtime.name == "APPSYNC_JS", false) ? null : "{}")
-  response_template = lookup(each.value, "response_template", tobool(lookup(each.value, "direct_lambda", false)) ? var.direct_lambda_response_template : try(each.value.kind == "PIPELINE" && each.value.runtime.name == "APPSYNC_JS", false) ? null : "{}")
+  request_template  = lookup(each.value, "request_template", tobool(lookup(each.value, "direct_lambda", false)) ? var.direct_lambda_request_template : try(each.value.runtime.name == "APPSYNC_JS", false) ? null : "{}")
+  response_template = lookup(each.value, "response_template", tobool(lookup(each.value, "direct_lambda", false)) ? var.direct_lambda_response_template : try(each.value.runtime.name == "APPSYNC_JS", false) ? null : "{}")
 
   data_source = lookup(each.value, "data_source", null) != null ? aws_appsync_datasource.this[each.value.data_source].name : lookup(each.value, "data_source_arn", null)
 


### PR DESCRIPTION
## Description
Remove the requirement for the resolver 'kind' property to be 'PIPELINE'. Currently both 'UNIT' and 'PIPELINE' resolvers allow for code to be added when the runtime is `APPSYNC_JS`.

## Motivation and Context
Fixes #54 

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
