### PR TITLE
feat: Add support for opensearch and eventbridge datasources

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ module "appsync" {
       endpoint = "https://search-my-domain.eu-west-1.es.amazonaws.com"
       region   = "eu-west-1"
     }
+
+    opensearchservice1 = {
+      type     = "AMAZON_OPENSEARCH_SERVICE"
+      endpoint = "https://opensearch-my-domain.eu-west-1.es.amazonaws.com"
+      region   = "eu-west-1"
+    }
   }
 
   resolvers = {
@@ -185,6 +191,7 @@ No modules.
 | <a name="input_logs_role_tags"></a> [logs\_role\_tags](#input\_logs\_role\_tags) | Map of tags to add to Cloudwatch logs IAM role | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of GraphQL API | `string` | `""` | no |
 | <a name="input_openid_connect_config"></a> [openid\_connect\_config](#input\_openid\_connect\_config) | Nested argument containing OpenID Connect configuration. | `map(string)` | `{}` | no |
+| <a name="input_opensearchservice_allowed_actions"></a> [opensearchservice\_allowed\_actions](#input\_opensearchservice\_allowed\_actions) | List of allowed IAM actions for datasources type AMAZON\_OPENSEARCH\_SERVICE | `list(string)` | <pre>[<br>  "es:ESHttpDelete",<br>  "es:ESHttpHead",<br>  "es:ESHttpGet",<br>  "es:ESHttpPost",<br>  "es:ESHttpPut"<br>]</pre> | no |
 | <a name="input_resolver_caching_ttl"></a> [resolver\_caching\_ttl](#input\_resolver\_caching\_ttl) | Default caching TTL for resolvers when caching is enabled | `number` | `60` | no |
 | <a name="input_resolvers"></a> [resolvers](#input\_resolvers) | Map of resolvers to create | `any` | `{}` | no |
 | <a name="input_schema"></a> [schema](#input\_schema) | The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ module "appsync" {
       endpoint = "https://opensearch-my-domain.eu-west-1.es.amazonaws.com"
       region   = "eu-west-1"
     }
+
+    eventbridge1 = {
+      type     = "AMAZON_EVENTBRIDGE"
+      event_bus_arn = "aws:arn:events:us-west-1:135367859850:event-bus/eventbridge1"
+    }
   }
 
   resolvers = {
@@ -178,6 +183,7 @@ No modules.
 | <a name="input_domain_name_description"></a> [domain\_name\_description](#input\_domain\_name\_description) | A description of the Domain Name. | `string` | `null` | no |
 | <a name="input_dynamodb_allowed_actions"></a> [dynamodb\_allowed\_actions](#input\_dynamodb\_allowed\_actions) | List of allowed IAM actions for datasources type AMAZON\_DYNAMODB | `list(string)` | <pre>[<br>  "dynamodb:GetItem",<br>  "dynamodb:PutItem",<br>  "dynamodb:DeleteItem",<br>  "dynamodb:UpdateItem",<br>  "dynamodb:Query",<br>  "dynamodb:Scan",<br>  "dynamodb:BatchGetItem",<br>  "dynamodb:BatchWriteItem"<br>]</pre> | no |
 | <a name="input_elasticsearch_allowed_actions"></a> [elasticsearch\_allowed\_actions](#input\_elasticsearch\_allowed\_actions) | List of allowed IAM actions for datasources type AMAZON\_ELASTICSEARCH | `list(string)` | <pre>[<br>  "es:ESHttpDelete",<br>  "es:ESHttpHead",<br>  "es:ESHttpGet",<br>  "es:ESHttpPost",<br>  "es:ESHttpPut"<br>]</pre> | no |
+| <a name="input_eventbridge_allowed_actions"></a> [eventbridge\_allowed\_actions](#input\_eventbridge\_allowed\_actions) | List of allowed IAM actions for datasources type AMAZON\_EVENTBRIDGE | `list(string)` | <pre>[<br>  "events:PutEvents"<br>]</pre> | no |
 | <a name="input_functions"></a> [functions](#input\_functions) | Map of functions to create | `any` | `{}` | no |
 | <a name="input_graphql_api_tags"></a> [graphql\_api\_tags](#input\_graphql\_api\_tags) | Map of tags to add to GraphQL API | `map(string)` | `{}` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | ARN for iam permissions boundary | `string` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -222,6 +222,12 @@ module "appsync" {
       endpoint = "https://search-my-domain-2.eu-west-1.es.amazonaws.com"
       region   = "eu-west-1"
     }
+
+    eventbridge1 = {
+      type = "AMAZON_EVENTBRIDGE"
+
+      event_bus_arn = "aws:arn:events:us-west-1:135367859850:event-bus/eventbridge1"
+    }
   }
 
   resolvers = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -213,6 +213,15 @@ module "appsync" {
       endpoint = "https://search-my-domain.eu-west-1.es.amazonaws.com"
       region   = "eu-west-1"
     }
+
+    # Opensearch Service support has not been finished & tested
+    opensearchservice1 = {
+      type = "AMAZON_OPENSEARCH_SERVICE"
+
+      # Note: dynamic references (module.opensearchservice1.id) do not work do not work unless you create this resource in advance
+      endpoint = "https://search-my-domain-2.eu-west-1.es.amazonaws.com"
+      region   = "eu-west-1"
+    }
   }
 
   resolvers = {

--- a/iam.tf
+++ b/iam.tf
@@ -1,7 +1,7 @@
 data "aws_partition" "this" {}
 
 locals {
-  service_roles_with_policies = var.create_graphql_api ? { for k, v in var.datasources : k => v if contains(["AWS_LAMBDA", "AMAZON_DYNAMODB", "AMAZON_ELASTICSEARCH", "AMAZON_OPENSEARCH_SERVICE"], v.type) && tobool(lookup(v, "create_service_role", true)) } : {}
+  service_roles_with_policies = var.create_graphql_api ? { for k, v in var.datasources : k => v if contains(["AWS_LAMBDA", "AMAZON_DYNAMODB", "AMAZON_ELASTICSEARCH", "AMAZON_OPENSEARCH_SERVICE", "AMAZON_EVENTBRIDGE"], v.type) && tobool(lookup(v, "create_service_role", true)) } : {}
 
   service_roles_with_policies_lambda = { for k, v in local.service_roles_with_policies : k => merge(v,
     {
@@ -51,11 +51,24 @@ locals {
     }
   ) if v.type == "AMAZON_OPENSEARCH_SERVICE" }
 
+  service_roles_with_policies_eventbridge = { for k, v in local.service_roles_with_policies : k => merge(v,
+    {
+      policy_statements = {
+        eventbridge = {
+          effect    = "Allow"
+          actions   = lookup(v, "policy_actions", null) == null ? var.eventbridge_allowed_actions : v.policy_actions
+          resources = [v.event_bus_arn]
+        }
+      }
+    }
+  ) if v.type == "AMAZON_EVENTBRIDGE" }
+
   service_roles_with_specific_policies = merge(
     local.service_roles_with_policies_lambda,
     local.service_roles_with_policies_dynamodb,
     local.service_roles_with_policies_elasticsearch,
     local.service_roles_with_policies_opensearchservice,
+    local.service_roles_with_policies_eventbridge,
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_appsync_datasource" "this" {
   name             = each.key
   type             = each.value.type
   description      = lookup(each.value, "description", null)
-  service_role_arn = lookup(each.value, "service_role_arn", tobool(lookup(each.value, "create_service_role", contains(["AWS_LAMBDA", "AMAZON_DYNAMODB", "AMAZON_ELASTICSEARCH", "AMAZON_OPENSEARCH_SERVICE"], each.value.type))) ? aws_iam_role.service_role[each.key].arn : null)
+  service_role_arn = lookup(each.value, "service_role_arn", tobool(lookup(each.value, "create_service_role", contains(["AWS_LAMBDA", "AMAZON_DYNAMODB", "AMAZON_ELASTICSEARCH", "AMAZON_OPENSEARCH_SERVICE", "AMAZON_EVENTBRIDGE"], each.value.type))) ? aws_iam_role.service_role[each.key].arn : null)
 
   dynamic "http_config" {
     for_each = each.value.type == "HTTP" ? [true] : []
@@ -187,6 +187,14 @@ resource "aws_appsync_datasource" "this" {
     content {
       endpoint = each.value.endpoint
       region   = lookup(each.value, "region", null)
+    }
+  }
+
+  dynamic "event_bridge_config" {
+    for_each = each.value.type == "AMAZON_EVENTBRIDGE" ? [true] : []
+
+    content {
+      event_bus_arn = each.value.event_bus_arn
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_appsync_datasource" "this" {
   name             = each.key
   type             = each.value.type
   description      = lookup(each.value, "description", null)
-  service_role_arn = lookup(each.value, "service_role_arn", tobool(lookup(each.value, "create_service_role", contains(["AWS_LAMBDA", "AMAZON_DYNAMODB", "AMAZON_ELASTICSEARCH"], each.value.type))) ? aws_iam_role.service_role[each.key].arn : null)
+  service_role_arn = lookup(each.value, "service_role_arn", tobool(lookup(each.value, "create_service_role", contains(["AWS_LAMBDA", "AMAZON_DYNAMODB", "AMAZON_ELASTICSEARCH", "AMAZON_OPENSEARCH_SERVICE"], each.value.type))) ? aws_iam_role.service_role[each.key].arn : null)
 
   dynamic "http_config" {
     for_each = each.value.type == "HTTP" ? [true] : []
@@ -174,6 +174,15 @@ resource "aws_appsync_datasource" "this" {
 
   dynamic "elasticsearch_config" {
     for_each = each.value.type == "AMAZON_ELASTICSEARCH" ? [true] : []
+
+    content {
+      endpoint = each.value.endpoint
+      region   = lookup(each.value, "region", null)
+    }
+  }
+
+  dynamic "opensearchservice_config" {
+    for_each = each.value.type == "AMAZON_OPENSEARCH_SERVICE" ? [true] : []
 
     content {
       endpoint = each.value.endpoint

--- a/variables.tf
+++ b/variables.tf
@@ -236,6 +236,12 @@ variable "opensearchservice_allowed_actions" {
   default     = ["es:ESHttpDelete", "es:ESHttpHead", "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut"]
 }
 
+variable "eventbridge_allowed_actions" {
+  description = "List of allowed IAM actions for datasources type AMAZON_EVENTBRIDGE"
+  type        = list(string)
+  default     = ["events:PutEvents"]
+}
+
 variable "iam_permissions_boundary" {
   description = "ARN for iam permissions boundary"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -230,6 +230,12 @@ variable "elasticsearch_allowed_actions" {
   default     = ["es:ESHttpDelete", "es:ESHttpHead", "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut"]
 }
 
+variable "opensearchservice_allowed_actions" {
+  description = "List of allowed IAM actions for datasources type AMAZON_OPENSEARCH_SERVICE"
+  type        = list(string)
+  default     = ["es:ESHttpDelete", "es:ESHttpHead", "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut"]
+}
+
 variable "iam_permissions_boundary" {
   description = "ARN for iam permissions boundary"
   type        = string

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -36,6 +36,7 @@ module "wrapper" {
   lambda_allowed_actions             = try(each.value.lambda_allowed_actions, var.defaults.lambda_allowed_actions, ["lambda:invokeFunction"])
   dynamodb_allowed_actions           = try(each.value.dynamodb_allowed_actions, var.defaults.dynamodb_allowed_actions, ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem"])
   elasticsearch_allowed_actions      = try(each.value.elasticsearch_allowed_actions, var.defaults.elasticsearch_allowed_actions, ["es:ESHttpDelete", "es:ESHttpHead", "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut"])
+  opensearchservice_allowed_actions  = try(each.value.opensearchservice_allowed_actions, var.defaults.opensearchservice_allowed_actions, ["es:ESHttpDelete", "es:ESHttpHead", "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut"])
   iam_permissions_boundary           = try(each.value.iam_permissions_boundary, var.defaults.iam_permissions_boundary, null)
   direct_lambda_request_template = try(each.value.direct_lambda_request_template, var.defaults.direct_lambda_request_template, <<-EOF
   {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -37,6 +37,7 @@ module "wrapper" {
   dynamodb_allowed_actions           = try(each.value.dynamodb_allowed_actions, var.defaults.dynamodb_allowed_actions, ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem", "dynamodb:Query", "dynamodb:Scan", "dynamodb:BatchGetItem", "dynamodb:BatchWriteItem"])
   elasticsearch_allowed_actions      = try(each.value.elasticsearch_allowed_actions, var.defaults.elasticsearch_allowed_actions, ["es:ESHttpDelete", "es:ESHttpHead", "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut"])
   opensearchservice_allowed_actions  = try(each.value.opensearchservice_allowed_actions, var.defaults.opensearchservice_allowed_actions, ["es:ESHttpDelete", "es:ESHttpHead", "es:ESHttpGet", "es:ESHttpPost", "es:ESHttpPut"])
+  eventbridge_allowed_actions        = try(each.value.eventbridge_allowed_actions, var.defaults.eventbridge_allowed_actions, ["events:PutEvents"])
   iam_permissions_boundary           = try(each.value.iam_permissions_boundary, var.defaults.iam_permissions_boundary, null)
   direct_lambda_request_template = try(each.value.direct_lambda_request_template, var.defaults.direct_lambda_request_template, <<-EOF
   {


### PR DESCRIPTION
## Description
Adds support for Opensearch and Eventbridge data sources.

## Motivation and Context
This extends the module to add support for opensearch (released in aws provider version 4.64.0) and eventbridge (released in aws provider version 4.589.0)

## Breaking Changes
This does not introduce a breaking change. I believe these changes are backwards compatible.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
