### PR TITLE
fix: Rename resource aws_appsync_api_cache

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "aws_appsync_domain_name_api_association" "this" {
 }
 
 # API Cache
-resource "aws_appsync_api_cache" "example" {
+resource "aws_appsync_api_cache" "this" {
   count = var.create_graphql_api && var.caching_enabled ? 1 : 0
 
   api_id = aws_appsync_graphql_api.this[0].id


### PR DESCRIPTION
The name "example" is not appropriate in the module for the resource aws_appsync_api_cache

## Description
Rename aws_appsync_api_cache ressource as "example" seems an error

## Motivation and Context
It is sad in the states and logs of terrform plan - apply

## Breaking Changes
Necessary to add moved instruction to avoid destroy create resource. Probably a breaking change

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

