### PR TITLE
feat: Add role name suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ No modules.
 | <a name="input_resolver_caching_ttl"></a> [resolver\_caching\_ttl](#input\_resolver\_caching\_ttl) | Default caching TTL for resolvers when caching is enabled | `number` | `60` | no |
 | <a name="input_resolver_count_limit"></a> [resolver\_count\_limit](#input\_resolver\_count\_limit) | The maximum number of resolvers that can be invoked in a single request. | `number` | `null` | no |
 | <a name="input_resolvers"></a> [resolvers](#input\_resolvers) | Map of resolvers to create | `any` | `{}` | no |
+| <a name="input_role_suffix"></a> [role\_suffix](#input\_role\_suffix) | Suffix to append to generated role names | `string` | `""` | no |
 | <a name="input_schema"></a> [schema](#input\_schema) | The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration. | `string` | `""` | no |
 | <a name="input_secrets_manager_allowed_actions"></a> [secrets\_manager\_allowed\_actions](#input\_secrets\_manager\_allowed\_actions) | List of allowed IAM actions for secrets manager datasources type RELATIONAL\_DATABASE | `list(string)` | <pre>[<br>  "secretsmanager:GetSecretValue"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to add to all GraphQL resources created by this module | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ No modules.
 | <a name="input_resolver_caching_ttl"></a> [resolver\_caching\_ttl](#input\_resolver\_caching\_ttl) | Default caching TTL for resolvers when caching is enabled | `number` | `60` | no |
 | <a name="input_resolver_count_limit"></a> [resolver\_count\_limit](#input\_resolver\_count\_limit) | The maximum number of resolvers that can be invoked in a single request. | `number` | `null` | no |
 | <a name="input_resolvers"></a> [resolvers](#input\_resolvers) | Map of resolvers to create | `any` | `{}` | no |
-| <a name="input_role_suffix"></a> [role\_suffix](#input\_role\_suffix) | Suffix to append to generated role names | `string` | `""` | no |
+| <a name="input_role_suffix"></a> [role\_suffix](#input\_role\_suffix) | value to append to the role name | `string` | `""` | no |
 | <a name="input_schema"></a> [schema](#input\_schema) | The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration. | `string` | `""` | no |
 | <a name="input_secrets_manager_allowed_actions"></a> [secrets\_manager\_allowed\_actions](#input\_secrets\_manager\_allowed\_actions) | List of allowed IAM actions for secrets manager datasources type RELATIONAL\_DATABASE | `list(string)` | <pre>[<br>  "secretsmanager:GetSecretValue"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to add to all GraphQL resources created by this module | `map(string)` | `{}` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "assume_role" {
 resource "aws_iam_role" "logs" {
   count = var.logging_enabled && var.create_logs_role ? 1 : 0
 
-  name                 = coalesce(var.logs_role_name, "${var.name}-logs")
+  name                 = "${coalesce(var.logs_role_name, "${var.name}-logs")}${var.role_suffix}"
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
   permissions_boundary = var.iam_permissions_boundary
 
@@ -126,7 +126,7 @@ resource "aws_iam_role_policy_attachment" "logs" {
 resource "aws_iam_role" "service_role" {
   for_each = local.service_roles_with_specific_policies
 
-  name                 = lookup(each.value, "service_role_name", "${each.key}-role")
+  name                 = "${lookup(each.value, "service_role_name", "${each.key}-role")}${var.role_suffix}"
   permissions_boundary = var.iam_permissions_boundary
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -341,6 +341,6 @@ variable "resolver_count_limit" {
 
 variable "role_suffix" {
   description = "value to append to the role name"
-  type       = string
-  default    = ""
+  type        = string
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -338,3 +338,9 @@ variable "resolver_count_limit" {
   type        = number
   default     = null
 }
+
+variable "role_suffix" {
+  description = "value to append to the role name"
+  type       = string
+  default    = ""
+}

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -12,9 +12,9 @@ This wrapper does not implement any extra functionality.
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/appsync/aws//wrappers"
+  source = "tfr:///terraform-aws-modules/lint/aws//wrappers"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-appsync.git//wrappers?ref=master"
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-lint.git//wrappers?ref=master"
 }
 
 inputs = {
@@ -42,7 +42,7 @@ inputs = {
 
 ```hcl
 module "wrapper" {
-  source = "terraform-aws-modules/appsync/aws//wrappers"
+  source = "terraform-aws-modules/lint/aws//wrappers"
 
   defaults = { # Default values
     create = true

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -68,6 +68,7 @@ module "wrapper" {
   resolver_caching_ttl                = try(each.value.resolver_caching_ttl, var.defaults.resolver_caching_ttl, 60)
   resolver_count_limit                = try(each.value.resolver_count_limit, var.defaults.resolver_count_limit, null)
   resolvers                           = try(each.value.resolvers, var.defaults.resolvers, {})
+  role_suffix                         = try(each.value.role_suffix, var.defaults.role_suffix, "")
   schema                              = try(each.value.schema, var.defaults.schema, "")
   secrets_manager_allowed_actions     = try(each.value.secrets_manager_allowed_actions, var.defaults.secrets_manager_allowed_actions, ["secretsmanager:GetSecretValue"])
   tags                                = try(each.value.tags, var.defaults.tags, {})


### PR DESCRIPTION
## Description
add optional input whose value is appended to generated role names to prevent collisions in same account

## Motivation and Context
if you want to deploy multiple instances of a configuration using this module in the same account, without this change, the role names would collide

## Breaking Changes
no

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
- [X] Other
I used this module in the development of an application config module.
The issue was discovered by invoking my module twice.
Collisions were resolved in other resources in my module.
The appsync module provided needed forked because there was no provision to change the generated datasource roles.
After the changes were made and the proper inputs provided, I was able to deploy two side by side instances of my app module.