### PR TITLE
add type descriptions for complex input

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -199,6 +199,7 @@ module "appsync" {
       # Note: dynamic references (module.aws_lambda_function2.lambda_function_arn) do not work unless you create this resource in advance
       function_arn = "arn:aws:lambda:eu-west-1:835367859851:function:index_2"
       # service_role_arn = "arn:aws:iam::835367859851:role/lambda1-service"
+      service_role_name = "lambda2-custom-name-service-role"
     }
 
     dynamodb1 = {

--- a/variables.tf
+++ b/variables.tf
@@ -304,8 +304,34 @@ variable "resolver_caching_ttl" {
 # Datasources
 variable "datasources" {
   description = "Map of datasources to create"
-  type        = any
-  default     = {}
+  description = <<EOF
+  Map of datasources to create. The key is the name of the datasource and the value is a map of the datasource configuration. The configuration map must contain the following keys:
+  - type: The type of the datasource. Valid values are: AWS_LAMBDA, AMAZON_DYNAMODB, AMAZON_ELASTICSEARCH, AMAZON_OPENSEARCH_SERVICE, AMAZON_EVENTBRIDGE, RELATIONAL_DATABASE
+  - service_role_name: The name of the service role, to override default.
+  - endpoint: The endpoint of the datasource. Required for AWS_LAMBDA, AMAZON_ELASTICSEARCH, AMAZON_OPENSEARCH_SERVICE
+  - region: The region of the datasource. Required for AMAZON_DYNAMODB, AMAZON_ELASTICSEARCH, AMAZON_OPENSEARCH_SERVICE
+  - table_name: The name of the table. Required for AMAZON_DYNAMODB
+  - event_bus_name: The name of the event bus. Required for AMAZON_EVENTBRIDGE
+  - cluster_arn: The ARN of the cluster. Required for RELATIONAL_DATABASE
+  - secret_arn: The ARN of the secret. Required for RELATIONAL_DATABASE
+  - database_name: The name of the database. Required for RELATIONAL_DATABASE
+  - schema: The schema of the database. Required for RELATIONAL_DATABASE
+EOF
+  type = object({
+    name = object({
+      type              = string
+      endpoint          = optional(string)
+      region            = optional(string)
+      table_name        = optional(string)
+      event_bus_name    = optional(string)
+      cluster_arn       = optional(string)
+      secret_arn        = optional(string)
+      database_name     = optional(string)
+      schema            = optional(string)
+      service_role_name = optional(string)
+    })
+  })
+  default = {}
 }
 
 # Resolvers

--- a/variables.tf
+++ b/variables.tf
@@ -303,11 +303,11 @@ variable "resolver_caching_ttl" {
 
 # Datasources
 variable "datasources" {
-  description = "Map of datasources to create"
   description = <<EOF
   Map of datasources to create. The key is the name of the datasource and the value is a map of the datasource configuration. The configuration map must contain the following keys:
   - type: The type of the datasource. Valid values are: AWS_LAMBDA, AMAZON_DYNAMODB, AMAZON_ELASTICSEARCH, AMAZON_OPENSEARCH_SERVICE, AMAZON_EVENTBRIDGE, RELATIONAL_DATABASE
   - service_role_name: The name of the service role, to override default.
+  - service_role_arn: The ARN of an existing service role
   - endpoint: The endpoint of the datasource. Required for AWS_LAMBDA, AMAZON_ELASTICSEARCH, AMAZON_OPENSEARCH_SERVICE
   - region: The region of the datasource. Required for AMAZON_DYNAMODB, AMAZON_ELASTICSEARCH, AMAZON_OPENSEARCH_SERVICE
   - table_name: The name of the table. Required for AMAZON_DYNAMODB
@@ -329,6 +329,7 @@ EOF
       database_name     = optional(string)
       schema            = optional(string)
       service_role_name = optional(string)
+      service_role_arn  = optional(string)
     })
   })
   default = {}


### PR DESCRIPTION
## Description
attempt describing datasources input with complex type

it's my first time using these, and i'm also not 100% sure it captures everything about the module. just hoping to move the bar a little bit.

## Motivation and Context
unclear what options are supported for data sources; caused #64 to be made then closed. documentation followup.

## Breaking Changes
none

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - at least passed validation, but configuration is not applyable in my account as is - tweaked zone but gave up after acm validation error
- [X] I have executed `pre-commit run -a` on my pull request
```
hunter.morgan@INV-04069 terraform-aws-appsync % docker run -e "USERID=$(id -u):$(id -g)" -v $(pwd):/lint -w /lint ghcr.io/antonbabenko/pre-commit-terraform:$TAG run -a

[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Terraform fmt............................................................Passed
Terraform wrapper with for_each in module................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Failed
- hook id: terraform_validate
- exit code: 1

Validation failed: examples/complete
╷
│ Error: missing or corrupted provider plugins:
│   - registry.terraform.io/hashicorp/aws: there is no package for registry.terraform.io/hashicorp/aws 5.65.0 cached in .terraform/providers
│   - registry.terraform.io/hashicorp/random: there is no package for registry.terraform.io/hashicorp/random 3.6.2 cached in .terraform/providers
│ 
│ 
╵

check for merge conflicts................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
hunter.morgan@INV-04069 terraform-aws-appsync % terraform validate
Success! The configuration is valid.

hunter.morgan@INV-04069 terraform-aws-appsync % 
```
